### PR TITLE
Add a website for shtk

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,0 +1,22 @@
+name: Deploy site
+
+on:
+    push:
+        branches:
+            - master
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - run: sudo apt-get install -y mandoc pandoc
+            - run: autoreconf -isv
+            - run: ./configure
+            - run: make site
+            - uses: JamesIves/github-pages-deploy-action@4.1.4
+              with:
+                folder: site-out
+                repository-name: jmmv/shtk
+                branch: gh-pages
+                ssh-key: ${{ secrets.SHTK_SITE_DEPLOY_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,7 @@ man/shtk.1
 man/shtk_import.3
 shtk
 shtk.pc
+site/build
+site-out
 test-suite.log
 version.subr

--- a/Makefile.am
+++ b/Makefile.am
@@ -314,3 +314,10 @@ clean-all:
 	GIT="$(GIT)" $(SH) $(srcdir)/admin/clean-all.sh
 
 .PHONY: $(PHONY_TARGETS)
+
+site/build: $(srcdir)/site/build.sh shtk
+	$(AM_V_GEN)$(TESTS_ENVIRONMENT) ./shtk build -o $@ $<
+
+PHONY_TARGETS += site
+site: all site/build
+	@$(TESTS_ENVIRONMENT) ./site/build -o site-out "-v$(PACKAGE_VERSION)"

--- a/README.md
+++ b/README.md
@@ -14,11 +14,7 @@ shtk is purely written in the shell scripting language so there are **no
 dependencies** to be installed.
 
 shtk is **known to be compatible with at least bash, dash, pdksh and zsh**,
-and continuous integration tests on Travis CI prove this to be the case.
-It is also true that shtk runs on other shells like the native `/bin/sh`
-interpreter of the BSD systems but, unfortunately, no assurances can be
-made in this regard by the continuous integration system due to Travis CI
-limitations
+and continuous integration tests prove this to be the case.
 
 shtk is licensed under a **[liberal BSD 3-clause license](LICENSE)**.
 
@@ -60,20 +56,9 @@ command-line utility and type `man 3 shtk` to open the introductory page to
 the API reference manual.  The `SEE ALSO` sections will guide you through
 the rest of the documentation.
 
-As a quick introduction, here are the modules supplied by `shtk`:
+You can access pre-built versions of the documentation online by visiting:
 
-* `bool`: Utilities to manipulate boolean values.
-* `cleanup`: Utilities to install "at-exit" handlers.
-* `cli`: Utilities to implement clean and consistent command-line
-  interfaces, including logging primitives.
-* `config`: Configuration file parser.
-* `cvs`: Utilities to interact with the CVS version control system.
-* `list`: Utilities to manipulate lists represented as a collection of
-  arguments.
-* `process`: Utilities to execute external processes.
-* `unittest`: Framework to implement unit- and integration-test test
-  programs.
-* `version`: Utilities to check the in-use version of `shtk`.
+> <https://shtk.jmmv.dev/>
 
 
 Support

--- a/site/CNAME
+++ b/site/CNAME
@@ -1,0 +1,1 @@
+shtk.jmmv.dev

--- a/site/build.sh
+++ b/site/build.sh
@@ -1,0 +1,117 @@
+# Copyright 2023 Julio Merino
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+# * Neither the name of Google Inc. nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+shtk_import cli
+
+set -eu
+
+build_distdocs() {
+    local outdir="${1}"; shift
+
+    pandoc INSTALL.md >"${outdir}/install.html.frag"
+}
+
+build_docs() {
+    local outdir="${1}"; shift
+
+    shtk_cli_info "Converting mandoc to HTML..."
+    echo "<ul>" >>"${outdir}/docs.html.frag"
+    for src in man/*.[0-9]; do
+        dest="${src#man/}.html"
+        mandoc -Thtml -Ofragment -Oman=%N.%S.html "${src}" \
+            >"${outdir}/${dest}.frag"
+        echo "<li><a href=\"${dest}\">${dest}</a></li>" \
+            >>"${outdir}/docs.html.frag"
+    done
+    echo "</ul>" >>"${outdir}/docs.html.frag"
+}
+
+build_fragments() {
+    local outdir="${1}"; shift
+    local version="${1}"; shift
+
+    shtk_cli_info "Processing fragments..."
+    for src in "${outdir}"/*.frag; do
+        dest="${src%.frag}"
+
+        docs_active=
+        install_active=
+        case "${src}" in
+            */index.html*) ;;
+            */install.html*) install_active="active" ;;
+            *) docs_active="active" ;;
+        esac
+        cat site/header.html.in "${src}" site/footer.html.in \
+            | sed -e "s,@DOCS_ACTIVE@,${docs_active},g" \
+                  -e "s,@INSTALL_ACTIVE@,${install_active},g" >"${dest}" \
+                  -e "s,@SHTK_VERSION@,${version},g" >"${dest}"
+    done
+}
+
+main() {
+    local outdir=site-out
+    local version=0.0
+
+    while getopts ':o:v:' arg "${@}"; do
+        case "${arg}" in
+            o)  # Output directory.
+                outdir="${OPTARG}"
+                ;;
+
+            v)  # Version to embed in the documentation.
+                version="${OPTARG}"
+                ;;
+
+            :)
+                shtk_cli_error "Missing argument to option -${OPTARG} in build"
+                ;;
+
+            \?)
+                shtk_cli_error "Unknown option -${OPTARG} in build"
+                ;;
+        esac
+    done
+    shift $((${OPTIND} - 1))
+
+    [ ${#} -eq 0 ] || shtk_cli_error "build takes zero arguments"
+
+    rm -rf "${outdir}"
+    mkdir "${outdir}"
+
+    cp site/CNAME "${outdir}"/
+    cp site/*.frag "${outdir}"/
+    cp site/styles.css "${outdir}"/
+
+    build_distdocs "${outdir}"
+
+    build_docs "${outdir}"
+
+    build_fragments "${outdir}" "${version}"
+
+    rm "${outdir}"/*.frag
+}

--- a/site/docs.html.frag
+++ b/site/docs.html.frag
@@ -1,0 +1,3 @@
+<h1>Reference manual</h1>
+
+<p>The manual pages below correspond to shtk @SHTK_VERSION@.</p>

--- a/site/footer.html.in
+++ b/site/footer.html.in
@@ -1,0 +1,8 @@
+        </div>
+      </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
+    <script src="main.js"></script>
+  </body>
+</html>

--- a/site/header.html.in
+++ b/site/header.html.in
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Shell Tookit (shtk)</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
+    <link rel="stylesheet" href="styles.css">
+  </head>
+
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+      <div class="container">
+        <a class="navbar-brand" href="index.html">shtk</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+            <li class="nav-item">
+              <a class="nav-link" href="https://github.com/jmmv/shtk/releases/" target="_blank">Download</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link @INSTALL_ACTIVE@" href="install.html">Installation</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link @DOCS_ACTIVE@" href="docs.html">Documentation</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+
+    <div class="container my-5">
+      <div class="row">
+        <div class="col px-0">

--- a/site/index.html.frag
+++ b/site/index.html.frag
@@ -1,0 +1,28 @@
+<h1>Shell Tookit (shtk)</h1>
+
+<p class="fs-5">The Shell Toolkit, or shtk for short, is an <b>application
+toolkit</b> for programmers writing POSIX-compliant shell scripts.</p>
+
+<p class="fs-5">shtk provides a <b>collection of reusable modules</b> that work
+on a wide variety of operating systems and shell interpreters.  These modules
+are all ready to be used by calling the
+provided <a href="shtk_import.3.html"><tt>shtk_import</tt> primitive</a> and
+"compiling" the shell scripts into their final form using
+the <a href="shtk.1.html"><tt>shtk(1)</tt> utility</a>.</p>
+
+<p class="fs-5">shtk is purely written in the shell scripting language so there
+are <b>no dependencies</b> to be installed.</p>
+
+<p class="fs-5">shtk is <b>known to be compatible with at least bash, dash,
+pdksh and zsh</b>, and continuous integration tests prove this to be the
+case.</p>
+
+<p class="fs-5">shtk is licensed under a liberal BSD 3-clause license and is
+brought to you by <a href="https://jmmv.dev/" target="_blank">Julio
+Merino</a>.</p>
+
+<a href="https://github.com/jmmv/shtk/releases/"
+   class="btn btn-primary">Download shtk</a>
+<a href="docs.html" class="btn btn-primary">Read the shtk docs</a>
+<a href="https://github.com/jmmv/shtk" class="btn btn-secondary">View on
+GitHub</a>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,50 @@
+table.head {
+    border-style: solid;
+    border-width: 0 0 1px 0;
+    font-weight: bold;
+    margin-bottom: 2em;
+    width: 100%;
+}
+td.head-ltitle {
+    text-align: left;
+}
+td.head-vol {
+    text-align: center;
+}
+td.head-rtitle {
+    text-align: right;
+}
+
+table.foot {
+    border-style: solid;
+    border-width: 1px 0 0 0;
+    font-weight: bold;
+    margin-top: 2em;
+    width: 100%;
+}
+td.foot-date {
+    text-align: left;
+}
+td.foot-os {
+    text-align: right;
+}
+
+h1.Sh {
+    margin-top: 1em;
+}
+a.permalink {
+    text-transform: initial;
+    text-decoration: none;
+}
+
+dl {
+    margin-left: 1em;
+}
+dl dd {
+    margin-left: 2em;
+}
+
+pre {
+    padding: 1em;
+    background: #eee;
+}


### PR DESCRIPTION
This creates a minimal website for shtk with the main goal of hosting the reference manual.  Otherwise, it's impossible for potential users to see all of the features included in this library.

This is intentionally simple.  I'm choosing to just create my own bespoke templating system to generate the pages given that most of the work here is integrating with mandoc.