### PR TITLE
Add bourne shell to CI and website

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,19 @@ jobs:
             - run: sudo apt-get install mksh cvs
             - run: ./.github/workflows/build.sh ksh "cvs"
 
+    sh-nothing:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - run: ./.github/workflows/build.sh sh ""
+
+    sh-cvs:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - run: sudo apt-get install cvs
+            - run: ./.github/workflows/build.sh sh "cvs"
+
     zsh-nothing:
         runs-on: ubuntu-latest
         steps:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ utility.
 shtk is purely written in the shell scripting language so there are **no
 dependencies** to be installed.
 
-shtk is **known to be compatible with at least bash, dash, pdksh and zsh**,
+shtk is **known to be compatible with at least bourne shell, bash, dash, pdksh and zsh**,
 and continuous integration tests prove this to be the case.
 
 shtk is licensed under a **[liberal BSD 3-clause license](LICENSE)**.

--- a/site/index.html.frag
+++ b/site/index.html.frag
@@ -13,7 +13,7 @@ the <a href="shtk.1.html"><tt>shtk(1)</tt> utility</a>.</p>
 <p class="fs-5">shtk is purely written in the shell scripting language so there
 are <b>no dependencies</b> to be installed.</p>
 
-<p class="fs-5">shtk is <b>known to be compatible with at least bash, dash,
+<p class="fs-5">shtk is <b>known to be compatible with at least bourne shell, bash, dash,
 pdksh and zsh</b>, and continuous integration tests prove this to be the
 case.</p>
 


### PR DESCRIPTION
When I came across this tool, I wondered if it worked for bourne shell. I assumed it would, because you mention POSIX, and I've read a bunch of your blog posts. Still, I wasn't sure since it wasn't explicit.

Perhaps you think it's obvious and doesn't need stating, but I thought it is worthwhile to explicitly state bourne shell and run CI against it.

One question: is `/bin/sh` on ubuntu actually bourne shell, or is it something else?